### PR TITLE
Make a cv type naming consistent

### DIFF
--- a/nltools/analysis.py
+++ b/nltools/analysis.py
@@ -1,7 +1,7 @@
 '''
     NeuroLearn Analysis Tools
     =========================
-    These tools provide the ability to quickly run 
+    These tools provide the ability to quickly run
     machine-learning analyses on imaging data
     Author: Luke Chang
     License: MIT
@@ -24,7 +24,7 @@ from nilearn.input_data import NiftiMasker
 import pandas as pd
 import numpy as np
 from nilearn.plotting import plot_stat_map
-import seaborn as sns    
+import seaborn as sns
 import matplotlib.pyplot as plt
 from nltools.plotting import dist_from_hyperplane_plot, scatterplot, probability_plot, roc_plot
 from nltools.stats import pearson
@@ -37,7 +37,7 @@ resource_dir = os.path.join(os.path.dirname(__file__),'resources')
 
 class Predict:
 
-    def __init__(self, data, Y, subject_id = None, algorithm=None, cv_dict=None, mask=None, 
+    def __init__(self, data, Y, subject_id = None, algorithm=None, cv_dict=None, mask=None,
                 output_dir='.', **kwargs):
         """ Initialize Predict.
 
@@ -45,21 +45,21 @@ class Predict:
             data: nibabel data instance
             Y: vector of training labels
             subject_id: vector of labels corresponding to each subject
-            algorithm: Algorithm to use for prediction.  Must be one of 'svm', 'svr', 
-                'linear', 'logistic', 'lasso', 'ridge', 'ridgeClassifier','randomforest', 
+            algorithm: Algorithm to use for prediction.  Must be one of 'svm', 'svr',
+                'linear', 'logistic', 'lasso', 'ridge', 'ridgeClassifier','randomforest',
                 or 'randomforestClassifier'
-            cv_dict: Type of cross_validation to use. A dictionary of {'kfold',5} or 
+            cv_dict: Type of cross_validation to use. A dictionary of {'kfold',5} or
                 {'loso':subject_id}.
             mask: binary nibabel mask
             output_dir: Directory to use for writing all outputs
             **kwargs: Additional keyword arguments to pass to the prediction algorithm
-        
+
         """
 
         self.output_dir = output_dir
-        
+
         if subject_id is not None:
-            self.subject_id = subject_id    
+            self.subject_id = subject_id
 
         if mask is not None:
             if type(mask) is not nib.nifti1.Nifti1Image:
@@ -67,12 +67,12 @@ class Predict:
             self.mask = mask
         else:
             self.mask = nib.load(os.path.join(resource_dir,'MNI152_T1_2mm_brain_mask_dil.nii.gz'))
-        
+
         if type(data) is not nib.nifti1.Nifti1Image:
             raise ValueError("data is not a nibabel instance")
         self.nifti_masker = NiftiMasker(mask_img=mask)
         self.data = self.nifti_masker.fit_transform(data)
-        
+
         if self.data.shape[0]!= len(Y):
             raise ValueError("Y does not match the correct size of data")
         self.Y = Y
@@ -83,27 +83,27 @@ class Predict:
         if cv_dict is not None:
             self.set_cv(cv_dict)
 
-    def predict(self, algorithm=None, cv_dict=None, save_images=True, save_output=True, 
+    def predict(self, algorithm=None, cv_dict=None, save_images=True, save_output=True,
         save_plot = True, **kwargs):
 
         """ Run prediction
 
         Args:
-            algorithm: Algorithm to use for prediction.  Must be one of 'svm', 'svr', 
-            'linear', 'logistic', 'lasso', 'ridge', 'ridgeClassifier','randomforest', 
+            algorithm: Algorithm to use for prediction.  Must be one of 'svm', 'svr',
+            'linear', 'logistic', 'lasso', 'ridge', 'ridgeClassifier','randomforest',
             or 'randomforestClassifier'
-            cv_dict: Type of cross_validation to use. A dictionary of {'kfold',5} or 
+            cv_dict: Type of cross_validation to use. A dictionary of {'kfold',5} or
             {'loso':subject_id}.
             save_images: Boolean indicating whether or not to save images to file.
             save_output: Boolean indicating whether or not to save prediction output to file.
             save_plot: Boolean indicating whether or not to create plots.
             **kwargs: Additional keyword arguments to pass to the prediction algorithm
- 
+
         """
-            
+
         if algorithm is not None:
             self.set_algorithm(algorithm, **kwargs)
-        
+
         if self.algorithm is None:
             raise ValueError("Make sure you specify an 'algorithm' to use.")
 
@@ -117,12 +117,12 @@ class Predict:
 
         # Cross-Validation Fit
         if cv_dict is not None:
-            self.set_cv(cv_dict)    
-        
+            self.set_cv(cv_dict)
+
         if hasattr(self,'cv'):
-            
+
             predicter_cv = self.predicter
-            
+
             if self.prediction_type is 'classification':
                 if self.algorithm not in ['svm','ridgeClassifier','ridgeClassifierCV']:
                     self.prob = np.zeros(len(self.Y))
@@ -134,7 +134,7 @@ class Predict:
             for train, test in self.cv:
                 predicter_cv.fit(self.data[train], self.Y[train])
                 self.yfit[test] = predicter_cv.predict(self.data[test])
-            
+
                 if self.prediction_type is 'classification':
                     if self.algorithm not in ['svm','ridgeClassifier','ridgeClassifierCV']:
                         self.prob[test] = predicter_cv.predict_proba(self.data[test])
@@ -142,22 +142,22 @@ class Predict:
                         xval_dist_from_hyperplane[test] = predicter_cv.decision_function(self.data[test])
                         if self.algorithm is 'svm' and self.predicter.probability:
                             self.prob[test] = predicter_cv.predict_proba(self.data[test])
-            
+
             if save_output:
                 self.stats_output = pd.DataFrame({
-                                    'SubID' : self.subject_id, 
-                                    'Y' : self.Y, 
+                                    'SubID' : self.subject_id,
+                                    'Y' : self.Y,
                                     'yfit' : self.yfit})
-                    
+
                 if self.prediction_type is 'classification':
                     if self.algorithm not in ['svm','ridgeClassifier','ridgeClassifierCV']:
                         self.stats_output['Probability'] = self.prob
                     else:
                         self.stats_output['xval_dist_from_hyperplane']=xval_dist_from_hyperplane
                         if self.algorithm is 'svm' and self.predicter.probability:
-                            self.stats_output['Probability'] = self.prob                    
+                            self.stats_output['Probability'] = self.prob
                 self._save_stats_output()
-                    
+
                 if save_plot:
                     self._save_plot(predicter_cv)
 
@@ -176,7 +176,7 @@ class Predict:
 
         Args:
             algorithm: The prediction algorithm to use. Either a string or an (uninitialized)
-            scikit-learn prediction object. If string, must be one of 'svm','svr', linear', 
+            scikit-learn prediction object. If string, must be one of 'svm','svr', linear',
             'logistic','lasso','lassopcr','lassoCV','ridge','ridgeCV','ridgeClassifier',
             'randomforest', or 'randomforestClassifier'
             kwargs: Additional keyword arguments to pass onto the scikit-learn clustering
@@ -233,24 +233,24 @@ class Predict:
             self._pca = PCA()
             self.predicter = Pipeline(steps=[('pca', self._pca), ('regress', self._regress)])
         else:
-            raise ValueError("""Invalid prediction/classification algorithm name. Valid 
-                options are 'svm','svr', 'linear', 'logistic', 'lasso', 'lassopcr', 
-                'lassoCV','ridge','ridgeCV','ridgeClassifier', 'randomforest', or 
+            raise ValueError("""Invalid prediction/classification algorithm name. Valid
+                options are 'svm','svr', 'linear', 'logistic', 'lasso', 'lassopcr',
+                'lassoCV','ridge','ridgeCV','ridgeClassifier', 'randomforest', or
                 'randomforestClassifier'.""")
 
     def set_cv(self, cv_dict):
         """ Set the CV algorithm to use in subsequent prediction analyses.
-        
+
         Args:
             cv_dict: Type of cross_validation to use. A dictionary of {'kfold',5} or {'loso':subject_id}.
-        
+
         """
 
         if type(cv_dict) is dict:
-            if cv_dict.keys()[0] is 'kfolds':
-                from  sklearn.cross_validation import StratifiedKFold
+            if cv_dict.keys()[0] == 'kfold':
+                from sklearn.cross_validation import StratifiedKFold
                 self.cv = StratifiedKFold(self.Y, n_folds=cv_dict.values()[0])
-            elif cv_dict.keys()[0] is 'loso':
+            elif cv_dict.keys()[0] == 'loso':
                 from sklearn.cross_validation import LeaveOneLabelOut
                 self.cv = LeaveOneLabelOut(labels=cv_dict.values()[0])
             else:
@@ -259,14 +259,14 @@ class Predict:
             raise ValueError("Make sure 'cv_dict' is a dictionary.")
 
     def _save_image(self, predicter):
-        """ Write out weight map to Nifti image. 
-        
+        """ Write out weight map to Nifti image.
+
         Args:
             predicter: predicter instance
 
         Returns:
             predicter_weightmap.nii.gz: Will output a nifti image of weightmap
-        
+
         """
 
         if not os.path.isdir(self.output_dir):
@@ -283,14 +283,14 @@ class Predict:
         nib.save(coef_img, os.path.join(self.output_dir, self.algorithm + '_weightmap.nii.gz'))
 
     def _save_stats_output(self):
-        """ Write stats output to csv file. 
-        
+        """ Write stats output to csv file.
+
         Args:
             stats_output: a pandas file with prediction output
 
         Returns:
             predicter_stats_output.csv: Will output a csv file of stats output
-        
+
         """
 
         if not os.path.isdir(self.output_dir):
@@ -298,8 +298,8 @@ class Predict:
         self.stats_output.to_csv(os.path.join(self.output_dir, self.algorithm + '_Stats_Output.csv'))
 
     def _save_plot(self, predicter):
-        """ Save Plots. 
-        
+        """ Save Plots.
+
         Args:
             predicter: predicter instance
 
@@ -311,7 +311,7 @@ class Predict:
 
         if not os.path.isdir(self.output_dir):
             os.makedirs(self.output_dir)
-        
+
         if self.algorithm is 'lassopcr':
             coef = np.dot(self._pca.components_.T,self._lasso.coef_)
             coef_img = self.nifti_masker.inverse_transform(np.transpose(coef))
@@ -323,7 +323,7 @@ class Predict:
 
         overlay_img = nib.load(os.path.join(resource_dir,'MNI152_T1_2mm_brain.nii.gz'))
 
-        fig1 = plot_stat_map(coef_img, overlay_img, title=self.algorithm + " weights", 
+        fig1 = plot_stat_map(coef_img, overlay_img, title=self.algorithm + " weights",
                             cut_coords=range(-40, 40, 10), display_mode='z')
         fig1.savefig(os.path.join(self.output_dir, self.algorithm + '_weightmap_axial.png'))
 
@@ -333,7 +333,7 @@ class Predict:
                 fig2.savefig(os.path.join(self.output_dir, self.algorithm + '_prob_plot.png'))
             else:
                 fig2 = dist_from_hyperplane_plot(self.stats_output)
-                fig2.savefig(os.path.join(self.output_dir, self.algorithm + 
+                fig2.savefig(os.path.join(self.output_dir, self.algorithm +
                             '_xVal_Distance_from_Hyperplane.png'))
                 if self.algorithm is 'svm' and self.predicter.probability:
                     fig3 = probability_plot(self.stats_output)
@@ -344,8 +344,8 @@ class Predict:
             fig2.savefig(os.path.join(self.output_dir, self.algorithm + '_scatterplot.png'))
 
 def apply_mask(data=None, weight_map=None, mask=None, method='dot_product', save_output=False, output_dir='.'):
-    """ Apply Nifti weight map to Nifti Images. 
- 
+    """ Apply Nifti weight map to Nifti Images.
+
         Args:
             data: nibabel instance of data to be applied
             weight_map: nibabel instance of weight map
@@ -358,23 +358,23 @@ def apply_mask(data=None, weight_map=None, mask=None, method='dot_product', save
         Returns:
             pexp: Outputs a vector of pattern expression values
 
-    """ 
+    """
 
     if mask is not None:
         if type(mask) is not nib.nifti1.Nifti1Image:
             raise ValueError("Mask is not a nibabel instance")
     else:
         mask = nib.load(os.path.join(resource_dir,'MNI152_T1_2mm_brain_mask_dil.nii.gz'))
-    
+
     if type(data) is not nib.nifti1.Nifti1Image:
         raise ValueError("Data is not a nibabel instance")
-    
+
     nifti_masker = NiftiMasker(mask_img=mask)
     data_masked = nifti_masker.fit_transform(data)
 
     if type(weight_map) is not nib.nifti1.Nifti1Image:
         raise ValueError("Weight_map is not a nibabel instance")
-    
+
     weight_map_masked = nifti_masker.fit_transform(weight_map)
 
     # Calculate pattern expression
@@ -390,7 +390,7 @@ def apply_mask(data=None, weight_map=None, mask=None, method='dot_product', save
 
 class Roc:
 
-    def __init__(self, input_values=None, binary_outcome=None, threshold_type='optimal_overall', 
+    def __init__(self, input_values=None, binary_outcome=None, threshold_type='optimal_overall',
         forced_choice=False, **kwargs):
         """ Initialize Roc instance. Object-Oriented version based on Tor Wager's Matlab roc_plot.m function
 
@@ -401,7 +401,7 @@ class Roc:
             **kwargs: Additional keyword arguments to pass to the prediction algorithm
 
         """
-        
+
         if len(input_values) != len(binary_outcome):
             raise ValueError("Data Problem: input_value and binary_outcome are different lengths.")
 
@@ -415,23 +415,23 @@ class Roc:
         self.input_values = input_values
         self.binary_outcome = binary_outcome
         self.threshold_type = threshold_type
-        self.forced_choice=forced_choice    
+        self.forced_choice=forced_choice
 
     def calculate(self, input_values=None, binary_outcome=None, criterion_values=None,
         threshold_type='optimal_overall', forced_choice=False, balanced_acc=False):
         """ Calculate Receiver Operating Characteristic plot (ROC) for single-interval
         classification.
-   
+
         Args:
             input_values: nibabel data instance
             binary_outcome: vector of training labels
             criterion_values: (optional) criterion values for calculating fpr & tpr
             threshold_type: ['optimal_overall', 'optimal_balanced','minimum_sdt_bias']
-            forced_choice: within-subject forced classification (bool).  Data must be 
+            forced_choice: within-subject forced classification (bool).  Data must be
             stacked on top of each other (e.g., [1 1 1 0 0 0]).
             balanced_acc: balanced accuracy for single-interval classification (bool)
             **kwargs: Additional keyword arguments to pass to the prediction algorithm
- 
+
         """
 
         if input_values is not None:
@@ -464,7 +464,7 @@ class Roc:
         self.n_false = float(sum(~self.binary_outcome))
 
         # Calculate Area Under the Curve
-        
+
         # fix for AUC = 1 if no overlap - code not working (tpr_unique and fpr_unique can be different lengths)
         # fpr_unique = np.unique(self.fpr)
         # tpr_unique = np.unique(self.tpr)
@@ -523,12 +523,12 @@ class Roc:
 
         Create a specific kind of ROC curve plot, based on input values
         along a continuous distribution and a binary outcome variable (logical).
-        
+
         Args:
             plot_method: type of plot ['gaussian','observed']
             binary_outcome: vector of training labels
             **kwargs: Additional keyword arguments to pass to the prediction algorithm
-        
+
         """
 
         self.calculate() # Calculate ROC parameters
@@ -537,10 +537,10 @@ class Roc:
             if self.forced_choice:
                 diff_scores = self.input_values[self.binary_outcome] - self.input_values[~self.binary_outcome]
                 mn_diff = np.mean(diff_scores)
-                d = mn_diff / np.std(diff_scores)                
+                d = mn_diff / np.std(diff_scores)
                 pooled_sd = np.std(diff_scores) / np.sqrt(2);
                 d_a_model = mn_diff / pooled_sd
-    
+
                 x = np.arange(-3,3,.1)
                 tpr_smooth = 1 - norm.cdf(x, d, 1)
                 fpr_smooth = 1 - norm.cdf(x, -d, 1)
@@ -567,7 +567,7 @@ class Roc:
 
     def summary(self):
         """ Display a formatted summary of ROC analysis.
-        
+
         """
 
         print("------------------------")


### PR DESCRIPTION
There is small inconsistency between documented arguments of  `Predict.set_cv()` and the arguments handling inside the method. Wherein docstring states the method required `kfold` key, the validation code expects a dict with a key `kfolds`. An exception raised by the validation code mentions `kfold` as in the docstring. 

Since the keys of `cv_dict` are named as correspondent cross validation types I suggest to drop the "s" in `kfolds` and use `kfold` instead.

Sorry for a multitude of changes, apparently my editor has stripped some dangling whitespaces. The meaningful changes are around line 205.