### PR TITLE
Fix an undefined attribute

### DIFF
--- a/nltools/analysis.py
+++ b/nltools/analysis.py
@@ -336,11 +336,11 @@ class Predict:
 
         if self.prediction_type == 'classification':
             if self.algorithm not in ['svm','ridgeClassifier','ridgeClassifierCV']:
-                self.stats_output['Probability'] = self.prob
+                self.stats_output['Probability'] = self.prob_xval
             else:
                 self.stats_output['dist_from_hyperplane_xval']=dist_from_hyperplane_xval
                 if self.algorithm == 'svm' and self.predictor.probability:
-                    self.stats_output['Probability'] = self.prob
+                    self.stats_output['Probability'] = self.prob_xval
 
         self.stats_output.to_csv(os.path.join(self.output_dir, self.algorithm + '_Stats_Output.csv'),index=False)
 


### PR DESCRIPTION
This fixes an `undefined attribute` exception that is raised while saving stats output after prediction.

I used a `prob_xval` attribute as a replacement since it used to be named `prob` [before this commit](https://github.com/ljchang/neurolearn/commit/4b7eb81ec88d92efa60cfafc3e0fdccc326fbd87#diff-321fc196315d60c56215e3f5bf02b97fL129).