### PR TITLE
bump nibabel version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 importlib
-nibabel>=2.0
+nibabel>=2.0.1
 scikit-learn
 nilearn>=0.1.2
 pandas>=0.13


### PR DESCRIPTION
Bumped the minimal required nibabel version to 2.0.1 since [axis argument](https://github.com/ljchang/neurolearn/blob/a560ba8a457a611916ca6b6070515dbfe1ba2ede/nltools/simulator.py#L265) in `concat_images()` appeared only in 2.0.1: https://github.com/nipy/nibabel/commit/c6c6a1de03d8838868af5c0540af9ef37c842284