### PR TITLE
set min version for scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,9 @@
 importlib
 nibabel>=2.0.1
-scikit-learn
+scikit-learn>=0.17
 nilearn>=0.1.2
 pandas>=0.13
 numpy>=1.9
 seaborn
 matplotlib
 scipy
-
-
-
-


### PR DESCRIPTION
It looks like I have a whole set of outdated libraries locally. The next thing I've bumped into is scikit-learn version 0.16 has a different set of `__init__` arguments in `_BaseKFold`. 

```python
    100 
    101     def __init__(self, y, n_folds=5, shuffle=False, random_state=None):
--> 102         super(KFoldStratified, self).__init__(len(y), n_folds, shuffle, random_state)
    103         self.y = y
    104         self.idxs = np.arange(len(y))

TypeError: __init__() takes exactly 6 arguments (5 given)
```

0.17 should work fine.